### PR TITLE
Fix stock trait deprecation warnings

### DIFF
--- a/src/HasStock.php
+++ b/src/HasStock.php
@@ -188,7 +188,7 @@ trait HasStock
      |--------------------------------------------------------------------------
      */
     
-    public function scopeWhereInStock($query, Warehouse $warehouse = null)
+    public function scopeWhereInStock($query, ?Warehouse $warehouse = null)
     {
         return $query->where(function ($query) use ($warehouse) {
             return $query->whereHas('stockMutations', function ($query) use ($warehouse) {
@@ -205,7 +205,7 @@ trait HasStock
         });
     }
     
-    public function scopeWhereOutOfStock($query, Warehouse $warehouse = null)
+    public function scopeWhereOutOfStock($query, ?Warehouse $warehouse = null)
     {
         return $query->where(function ($query) use ($warehouse) {
             return $query->whereHas('stockMutations', function ($query) use ($warehouse) {


### PR DESCRIPTION
Explicitly mark `Warehouse` parameters as nullable in `scopeWhereInStock` and `scopeWhereOutOfStock` to resolve deprecation warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f7eb52a-be30-47fb-8515-62f32fea43d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f7eb52a-be30-47fb-8515-62f32fea43d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `Warehouse` as nullable in `scopeWhereInStock` and `scopeWhereOutOfStock` method signatures.
> 
> - **Stock trait (`src/HasStock.php`)**:
>   - Update scope signatures to accept nullable warehouses:
>     - `scopeWhereInStock($query, ?Warehouse $warehouse = null)`
>     - `scopeWhereOutOfStock($query, ?Warehouse $warehouse = null)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e05bb64365ce939ff8a7353434567e068cc94ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->