### PR TITLE
Debug product stock warehouse association

### DIFF
--- a/src/HasStock.php
+++ b/src/HasStock.php
@@ -41,6 +41,11 @@ trait HasStock
      */
     public function stock($date = null, array $arguments = []): float
     {
+        if (is_array($date) && empty($arguments)) {
+            $arguments = $date;
+            $date = null;
+        }
+
         $date = $date ?: Carbon::now();
         
         if (! $date instanceof DateTimeInterface) {

--- a/tests/HasStockTest.php
+++ b/tests/HasStockTest.php
@@ -193,4 +193,13 @@ class HasStockTest extends TestCase
         $this->assertEquals(2, $this->stockModel->stock(Carbon::now()->subDays(14)->subMinutes(1)));
         $this->assertEquals(6, $this->stockModel->stock(Carbon::now()->subDays(14)->addMinutes(1)));
     }
+
+    /** @test */
+    public function it_can_fetch_stock_for_arguments_without_explicit_date_parameter()
+    {
+        $warehouse = WarehouseModel::create(['name' => 'ORD']);
+        $this->stockModel->setStock(12, ['warehouse' => $warehouse]);
+
+        $this->assertEquals(12, $this->stockModel->stock(['warehouse' => $warehouse]));
+    }
 }


### PR DESCRIPTION
Fix `TypeError` in `stock` method when filtering by warehouse without an explicit date.

The `stock` method was attempting to parse an array of arguments as a date when the date parameter was omitted, leading to a `TypeError`. This change ensures that if the first argument is an array and the second is empty, it's correctly treated as the arguments array.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4457a7c-191a-4478-aa9e-b85d8b395b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4457a7c-191a-4478-aa9e-b85d8b395b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle array as first parameter in `stock()` to pass arguments without an explicit date; add test covering warehouse filter usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48abbfa233e497e43e6878c761a040f6d8171a52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->